### PR TITLE
fix: trim whitespace from parcel name/description and reject blank-only description

### DIFF
--- a/src/main/java/com/eternalcode/parcellockers/gui/implementation/locker/SendingGui.java
+++ b/src/main/java/com/eternalcode/parcellockers/gui/implementation/locker/SendingGui.java
@@ -111,7 +111,7 @@ public class SendingGui implements GuiView {
                                 return;
                             }
 
-                            this.state.parcelName(name);
+                            this.state.parcelName(name.trim());
                             this.noticeService.player(player.getUniqueId(), messages -> messages.parcel.nameSet);
 
                             this.updateNameItem();
@@ -155,8 +155,9 @@ public class SendingGui implements GuiView {
                         200,
                         DialogAction.customClick((DialogResponseView view, Audience audience) -> {
                             String description = view.getText("description");
+                            String trimmedDescription = description != null ? description.trim() : null;
 
-                            this.state.parcelDescription(description);
+                            this.state.parcelDescription(trimmedDescription == null || trimmedDescription.isEmpty() ? null : trimmedDescription);
                             this.noticeService.player(player.getUniqueId(), messages -> messages.parcel.descriptionSet);
 
                             this.updateDescriptionItem();

--- a/src/main/java/com/eternalcode/parcellockers/gui/implementation/locker/SendingGui.java
+++ b/src/main/java/com/eternalcode/parcellockers/gui/implementation/locker/SendingGui.java
@@ -155,9 +155,9 @@ public class SendingGui implements GuiView {
                         200,
                         DialogAction.customClick((DialogResponseView view, Audience audience) -> {
                             String description = view.getText("description");
-                            String trimmedDescription = description != null ? description.trim() : null;
+                            String trimmedDescription = (description == null || description.isBlank()) ? null : description.trim();
 
-                            this.state.parcelDescription(trimmedDescription == null || trimmedDescription.isEmpty() ? null : trimmedDescription);
+                            this.state.parcelDescription(trimmedDescription);
                             this.noticeService.player(player.getUniqueId(), messages -> messages.parcel.descriptionSet);
 
                             this.updateDescriptionItem();


### PR DESCRIPTION
## Summary

- Fixes #219 — parcel name and description are now trimmed before being stored, stripping any leading/trailing spaces the player may have typed
- Fixes #220 — a description consisting entirely of spaces is coerced to `null` (treated as unset) rather than saved as a whitespace-only string

## Changes

Both fixes are in `SendingGui.java` inside the Paper Dialog response callbacks:

- **Name**: call `.trim()` on the raw input before passing it to `state.parcelName()`
- **Description**: trim the raw input; if the result is blank, store `null` instead of the whitespace string

## Test plan

- [ ] Enter a parcel name with leading/trailing spaces (e.g. `  My Parcel  `) — verify it is stored and displayed as `My Parcel`
- [ ] Enter a parcel description with leading/trailing spaces — verify it is trimmed
- [ ] Enter a description consisting only of spaces — verify it is treated as unset (description item shows the default "not set" appearance)
- [ ] Normal flow: name, description, receiver, destination all set correctly — verify parcel sends successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R4YqhTV42FvN95HanC7XJc